### PR TITLE
Do not count empty days for average per day

### DIFF
--- a/shared/src/commonMain/kotlin/me/timeto/shared/DayBarsUi.kt
+++ b/shared/src/commonMain/kotlin/me/timeto/shared/DayBarsUi.kt
@@ -44,7 +44,9 @@ class DayBarsUi(
             activeTimeFrom = activeTimeFrom,
         )
     }
-
+    fun dayContainsInterval(): Boolean {
+        return barsUi.any { it.intervalDb !=null }
+    }
     ///
 
     class BarUi(

--- a/shared/src/commonMain/kotlin/me/timeto/shared/vm/summary/SummaryVm.kt
+++ b/shared/src/commonMain/kotlin/me/timeto/shared/vm/summary/SummaryVm.kt
@@ -178,7 +178,7 @@ class SummaryVm : Vm<SummaryVm.State>() {
 private fun prepGoalsUi(
     daysBarsUi: List<DayBarsUi>
 ): List<SummaryVm.GoalUi> {
-    val daysCount = daysBarsUi.size
+    val daysCount = (daysBarsUi.count { it.dayContainsInterval() }).coerceAtLeast(1)
     val totalSeconds = daysCount * 86_400
     val mapGoalSeconds: MutableMap<Int, Int> = mutableMapOf()
     daysBarsUi.forEach { dayBarsUi ->


### PR DESCRIPTION
This is useful if you just downloaded the app and, e.g., have just 3 Days in the 30 Day view which contain anything. This way, the sleep is for example set to 8hrs a day and not ~50Minutes.

The coreceAtLeast should not be needed as the division with totalSeconds only happens if there is one interval, but to be sure (e.g, a 0 second interval or something) i added it.