### PR TITLE
Sending broadcast intent when timer started and expired

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,52 @@
+name: Build Android APK
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          cmdline-tools-version: '13114758'
+
+      - name: Install required SDK packages
+        run: |
+          sdkmanager "platforms;android-36" "build-tools;36.0.0" "platform-tools"
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission to gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build base debug APK
+        run: ./gradlew :android:assembleBaseDebug --no-daemon --stacktrace
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: timeto-base-debug-apk
+          path: android/build/outputs/apk/base/debug/*.apk
+          if-no-files-found: error
+          retention-days: 30

--- a/android/src/main/java/me/timeto/app/AlarmCenter.kt
+++ b/android/src/main/java/me/timeto/app/AlarmCenter.kt
@@ -8,6 +8,7 @@ import me.timeto.app.NotificationsUtils.NOTIFICATION_ID_BREAK
 import me.timeto.app.NotificationsUtils.NOTIFICATION_ID_NO_ACTIVITY_START
 import me.timeto.app.NotificationsUtils.NOTIFICATION_ID_OVERDUE
 import me.timeto.shared.NotificationAlarm
+import me.timeto.shared.db.IntervalDb
 import me.timeto.shared.timeMls
 
 object AlarmCenter {
@@ -25,6 +26,14 @@ object AlarmCenter {
         intent.putExtra(TimerNotificationReceiver.EXTRA_TITLE, data.title)
         intent.putExtra(TimerNotificationReceiver.EXTRA_TEXT, data.text)
         intent.putExtra(TimerNotificationReceiver.EXTRA_REQUEST_CODE, requestCode)
+
+        if (data.type == NotificationAlarm.Type.TimeToBreak) {
+            val timerType = data.liveActivity.timerType
+            if (timerType is IntervalDb.TimerType.Timer) {
+                intent.putExtra(TimerNotificationReceiver.EXTRA_AUTOMATION_ACTIVITY_NAME, data.liveActivity.dynamicIslandTitle)
+                intent.putExtra(TimerNotificationReceiver.EXTRA_AUTOMATION_TIMER_SECONDS, timerType.timer)
+            }
+        }
 
         TimerNotificationReceiver.liveDataEncode(intent, data.liveActivity)
 

--- a/android/src/main/java/me/timeto/app/AutomationBroadcast.kt
+++ b/android/src/main/java/me/timeto/app/AutomationBroadcast.kt
@@ -1,0 +1,19 @@
+package me.timeto.app
+
+import android.content.Context
+import android.content.Intent
+import me.timeto.shared.AUTOMATION_ACTION_TIMER_EXPIRED
+import me.timeto.shared.AUTOMATION_EXTRA_ACTIVITY_NAME
+import me.timeto.shared.AUTOMATION_EXTRA_TIMER_SECONDS
+
+object AutomationBroadcast {
+
+    fun sendTimerExpired(context: Context, activityName: String, timerSeconds: Int) {
+        context.sendBroadcast(
+            Intent(AUTOMATION_ACTION_TIMER_EXPIRED).apply {
+                putExtra(AUTOMATION_EXTRA_ACTIVITY_NAME, activityName)
+                putExtra(AUTOMATION_EXTRA_TIMER_SECONDS, timerSeconds)
+            }
+        )
+    }
+}

--- a/android/src/main/java/me/timeto/app/TimerNotificationReceiver.kt
+++ b/android/src/main/java/me/timeto/app/TimerNotificationReceiver.kt
@@ -18,6 +18,8 @@ class TimerNotificationReceiver : BroadcastReceiver() {
         const val EXTRA_TITLE = "title"
         const val EXTRA_TEXT = "text"
         const val EXTRA_REQUEST_CODE = "request_code"
+        const val EXTRA_AUTOMATION_ACTIVITY_NAME = "automation_activity_name"
+        const val EXTRA_AUTOMATION_TIMER_SECONDS = "automation_timer_seconds"
 
         // region EXTRA_LIVE
         private const val EXTRA_LIVE_TITLE = "live_title"
@@ -147,6 +149,13 @@ class TimerNotificationReceiver : BroadcastReceiver() {
             .build()
 
         manager.notify(requestCode, notification)
+
+        if (requestCode == NotificationsUtils.NOTIFICATION_ID_BREAK) {
+            val activityName = intent.getStringExtra(EXTRA_AUTOMATION_ACTIVITY_NAME)
+            val timerSeconds = intent.getIntExtra(EXTRA_AUTOMATION_TIMER_SECONDS, 0)
+            if (activityName != null && timerSeconds > 0)
+                AutomationBroadcast.sendTimerExpired(context, activityName, timerSeconds)
+        }
 
         // No matter if Live Updates disabled in app settings,
         // it will look like normal push replacement.

--- a/shared/src/androidMain/kotlin/me/timeto/shared/AutomationEvent.kt
+++ b/shared/src/androidMain/kotlin/me/timeto/shared/AutomationEvent.kt
@@ -1,0 +1,26 @@
+package me.timeto.shared
+
+import android.content.Intent
+
+const val AUTOMATION_ACTION_TIMER_STARTED = "me.timeto.app.TIMER_STARTED"
+const val AUTOMATION_ACTION_TIMER_EXPIRED = "me.timeto.app.TIMER_EXPIRED"
+const val AUTOMATION_ACTION_STOPWATCH_STARTED = "me.timeto.app.STOPWATCH_STARTED"
+const val AUTOMATION_EXTRA_ACTIVITY_NAME = "activity_name"
+const val AUTOMATION_EXTRA_TIMER_SECONDS = "timer_seconds"
+
+actual fun onTimerStarted(activityName: String, timerSeconds: Int) {
+    androidApplication.sendBroadcast(
+        Intent(AUTOMATION_ACTION_TIMER_STARTED).apply {
+            putExtra(AUTOMATION_EXTRA_ACTIVITY_NAME, activityName)
+            putExtra(AUTOMATION_EXTRA_TIMER_SECONDS, timerSeconds)
+        }
+    )
+}
+
+actual fun onStopwatchStarted(activityName: String) {
+    androidApplication.sendBroadcast(
+        Intent(AUTOMATION_ACTION_STOPWATCH_STARTED).apply {
+            putExtra(AUTOMATION_EXTRA_ACTIVITY_NAME, activityName)
+        }
+    )
+}

--- a/shared/src/commonMain/kotlin/me/timeto/shared/AutomationEvent.kt
+++ b/shared/src/commonMain/kotlin/me/timeto/shared/AutomationEvent.kt
@@ -1,0 +1,4 @@
+package me.timeto.shared
+
+expect fun onTimerStarted(activityName: String, timerSeconds: Int)
+expect fun onStopwatchStarted(activityName: String)

--- a/shared/src/commonMain/kotlin/me/timeto/shared/db/ActivityDb.kt
+++ b/shared/src/commonMain/kotlin/me/timeto/shared/db/ActivityDb.kt
@@ -13,6 +13,8 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import me.timeto.shared.Cache
+import me.timeto.shared.onStopwatchStarted
+import me.timeto.shared.onTimerStarted
 import me.timeto.shared.ColorRgba
 import me.timeto.shared.DaytimeUi
 import me.timeto.shared.HomeButtonSort
@@ -329,10 +331,16 @@ data class ActivityDb(
                 taskDb.delete()
             }
 
-        return IntervalDb.insertWithValidation(
+        val result = IntervalDb.insertWithValidation(
             activityDb = activityDb,
             note = note,
         )
+        val timerType = note?.textFeatures()?.timerType
+        if (timerType is TextFeatures.TimerType.Timer)
+            onTimerStarted(name, timerType.seconds)
+        else if (timerType is TextFeatures.TimerType.Stopwatch)
+            onStopwatchStarted(name)
+        return result
     }
 
     suspend fun startTimer(seconds: Int): IntervalDb {

--- a/shared/src/commonMain/kotlin/me/timeto/shared/db/IntervalDb.kt
+++ b/shared/src/commonMain/kotlin/me/timeto/shared/db/IntervalDb.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.jsonArray
 import me.timeto.shared.*
+import me.timeto.shared.onTimerStarted
 import me.timeto.shared.backups.Backupable__Holder
 import me.timeto.shared.backups.Backupable__Item
 import me.timeto.shared.getInt
@@ -152,6 +153,8 @@ data class IntervalDb(
         ///
 
         suspend fun pauseLastInterval(): Unit = dbIo {
+            var breakActivityName = ""
+            var breakTimerSeconds = 0
             db.transaction {
 
                 val now: Int = time()
@@ -222,11 +225,15 @@ data class IntervalDb(
                     pause = TextFeatures.Pause(pausedTaskId = pausedTaskId),
                     timerType = TextFeatures.TimerType.Timer(seconds = activityDb.pomodoro_timer),
                 )
+                val breakActivityDb = ActivityDb.selectOtherCached()
                 insertWithValidationNeedTransaction(
-                    activityDb = ActivityDb.selectOtherCached(),
+                    activityDb = breakActivityDb,
                     note = pauseIntervalTf.textWithFeatures(),
                 )
+                breakActivityName = breakActivityDb.name
+                breakTimerSeconds = activityDb.pomodoro_timer
             }
+            onTimerStarted(breakActivityName, breakTimerSeconds)
         }
 
         //
@@ -284,6 +291,7 @@ data class IntervalDb(
             timerType = TextFeatures.TimerType.Timer(timer),
         ).textWithFeatures()
         db.intervalQueries.updateNoteById(id = id, note = newNote)
+        onTimerStarted(selectActivityDbCached().name.textFeatures().textNoFeatures, timer)
     }
 
     @Throws(UiException::class, CancellationException::class)

--- a/shared/src/commonMain/kotlin/me/timeto/shared/db/TaskDb.kt
+++ b/shared/src/commonMain/kotlin/me/timeto/shared/db/TaskDb.kt
@@ -7,6 +7,8 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.jsonArray
 import me.timeto.shared.Cache
 import me.timeto.shared.TextFeatures
+import me.timeto.shared.onStopwatchStarted
+import me.timeto.shared.onTimerStarted
 import me.timeto.shared.TimerTimeParser
 import me.timeto.shared.launchExIo
 import me.timeto.shared.backups.Backupable__Holder
@@ -132,6 +134,10 @@ data class TaskDb(
             )
             db.taskQueries.deleteById(id)
         }
+        if (tfTimerType is TextFeatures.TimerType.Timer)
+            onTimerStarted(activityDb.name, tfTimerType.seconds)
+        else if (tfTimerType is TextFeatures.TimerType.Stopwatch)
+            onStopwatchStarted(activityDb.name)
     }
 
     suspend fun startTimer(

--- a/shared/src/iosMain/kotlin/me/timeto/shared/AutomationEvent.kt
+++ b/shared/src/iosMain/kotlin/me/timeto/shared/AutomationEvent.kt
@@ -1,0 +1,4 @@
+package me.timeto.shared
+
+actual fun onTimerStarted(activityName: String, timerSeconds: Int) {}
+actual fun onStopwatchStarted(activityName: String) {}

--- a/shared/src/watchosMain/kotlin/me/timeto/shared/AutomationEvent.kt
+++ b/shared/src/watchosMain/kotlin/me/timeto/shared/AutomationEvent.kt
@@ -1,0 +1,4 @@
+package me.timeto.shared
+
+actual fun onTimerStarted(activityName: String, timerSeconds: Int) {}
+actual fun onStopwatchStarted(activityName: String) {}


### PR DESCRIPTION
This merge request is described in the issue [Sending broadcast intent when timer started and expired](https://github.com/Medvedev91/timeto.me/issues/249)

## Changes

- Added implicit broadcast intents - that is to every app that wants to read it.
  - Timer started/expired broadcasts
  - Stopwatch started broadcast

This allows better automation with android apps such as Tasker.

- This merge request also contains a github CI build pipeline which is not intended to be pushed to the main branch. It may be deleted.


